### PR TITLE
Cria integração e build contínuo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: android
+before_install:
+- nvm install 13
+- node --version
+install:
+- npm install
+- yes | sdkmanager "platforms;android-28"
+script:
+- cd android && ./gradlew assembleRelease
+- cp app/build/outputs/apk/release/app-release.apk ..
+- cd ..
+deploy:
+  provider: releases
+  file: app-release.apk
+  on:
+    repo: Carisk/Carisk-frontend
+    all_branches: true
+    condition: $TRAVIS_BRANCH =~ ^(development)$
+  skip_cleanup: 'true'


### PR DESCRIPTION
*Descrição*

Como pedido na issue #5, esse PR cria uma configuração travis que builda e cria release no repositório.

Dessa forma, o time não precisa buildar o app para usar a última versão na development.